### PR TITLE
BSP-37: Assigning item shouldn't carry data fields over

### DIFF
--- a/contracts/Inventory.ligo
+++ b/contracts/Inventory.ligo
@@ -22,7 +22,7 @@ type action is
 
 type return is list (operation) * storage;
 
-function assign_item (const params: parameter; const storage: storage): return is
+function assign_item (const params: parameter; var storage: storage): return is
     block {
         const instances_map: option (item_instances) = storage.inventory[params.item_id];
 
@@ -30,30 +30,30 @@ function assign_item (const params: parameter; const storage: storage): return i
             None -> block {
                 const new_instances_map : item_instances = map [params.instance_number -> params.data];
 
-                storage.inventory := Big_map.add(params.item_id, new_instances_map, storage.inventory)
+                storage.inventory := Big_map.add (params.item_id, new_instances_map, storage.inventory)
             }
-            | Some(im) -> block {
-                im := Map.add(params.instance_number, params.data, im);
+            | Some (im) -> block {
+                const updated_im = Map.add (params.instance_number, params.data, im);
 
-                storage.inventory := Big_map.add(params.item_id, im, storage.inventory)
+                storage.inventory := Big_map.add (params.item_id, updated_im, storage.inventory)
             }
         end;
     } with ((nil: list (operation)), storage)
 
-function update_item (const params: parameter; const storage: storage): return is
+function update_item (const params: parameter; var storage: storage): return is
     block {
         const instances_map: option (item_instances) = storage.inventory[params.item_id];
 
         case instances_map of
-            None -> failwith("NO_SUCH_ITEM_IN_INVENTORY")
+            None -> failwith ("NO_SUCH_ITEM_IN_INVENTORY")
             | Some (im) -> block {
                 const instance: option (item_data) = im [params.instance_number];
 
                 case instance of
                     None -> failwith("NO_SUCH_INSTANCE_NUMBER")
                 |   Some (i) -> block {
-                    ignore_item_data(i);
-                    const updated_im : item_instances = Map.update(params.instance_number, Some (params.data), im);
+                    ignore_item_data (i);
+                    const updated_im : item_instances = Map.update (params.instance_number, Some (params.data), im);
                     storage.inventory [params.item_id] := updated_im
                 }
                 end;
@@ -63,6 +63,6 @@ function update_item (const params: parameter; const storage: storage): return i
 
 function main (const action: action; const storage: storage): return is
     case action of
-        Assign_item (i) -> assign_item(i, storage)
-    |   Update_item (i) -> update_item(i, storage)
+        Assign_item (i) -> assign_item (i, storage)
+    |   Update_item (i) -> update_item (i, storage)
     end

--- a/contracts/Warehouse.ligo
+++ b/contracts/Warehouse.ligo
@@ -36,11 +36,11 @@ type return is list (operation) * storage;
 
 function add (var item: item_metadata; var storage: storage): return is
     block {
-        const found_item: option(item_metadata) = storage.warehouse [item.item_id];
+        const found_item: option (item_metadata) = storage.warehouse [item.item_id];
 
         case found_item of
-            None -> storage.warehouse := Big_map.add(item.item_id, item, storage.warehouse)
-        |   Some (i) -> block { ignore_item_metadata(i); failwith("ITEM_ID_ALREADY_EXISTS")}
+            None -> storage.warehouse := Big_map.add (item.item_id, item, storage.warehouse)
+        |   Some (i) -> block { ignore_item_metadata (i); failwith ("ITEM_ID_ALREADY_EXISTS")}
         end;
     } with ((nil: list (operation)), storage)
 
@@ -49,7 +49,7 @@ function update (const item: item_metadata; var storage: storage): return is
         const found_item: option (item_metadata) = storage.warehouse [item.item_id];
 
         case found_item of
-            None -> failwith("ITEM_ID_DOESNT_EXIST")
+            None -> failwith ("ITEM_ID_DOESNT_EXIST")
         |   Some (i) -> {
                 const no_update_after : option (timestamp) = i.no_update_after;
 
@@ -57,14 +57,14 @@ function update (const item: item_metadata; var storage: storage): return is
                     None -> skip
                 |   Some (t) -> { 
                     if Tezos.now >= t then {
-                        failwith("ITEM_IS_FROZEN");
+                        failwith ("ITEM_IS_FROZEN");
                     } else {
                         skip;
                     }
                 }
                 end;
 
-                storage.warehouse := Big_map.update(item.item_id, Some(item), storage.warehouse);
+                storage.warehouse := Big_map.update (item.item_id, Some (item), storage.warehouse);
         }
         end;
     } with ((nil: list (operation)), storage)
@@ -75,7 +75,7 @@ function assign (const params: assign_parameter; var storage: storage): return i
         const found_item: option (item_metadata) = storage.warehouse[params.1];
 
         case found_item of
-            None -> failwith("ITEM_DOESNT_EXIST")
+            None -> failwith ("ITEM_DOESNT_EXIST")
             | Some (fi) -> {
                 const available_quantity : nat = fi.available_quantity;
                 const total_quantity : nat = fi.total_quantity;
@@ -84,13 +84,13 @@ function assign (const params: assign_parameter; var storage: storage): return i
                     failwith ("NO_AVAILABLE_ITEM");
                 } else {
                     const inventory : contract (inventory_parameter) =
-                        case (Tezos.get_entrypoint_opt("%assign_item", params.0) : option (contract (inventory_parameter))) of
+                        case (Tezos.get_entrypoint_opt ("%assign_item", params.0) : option (contract (inventory_parameter))) of
                             Some (contract) -> contract
                             | None -> (failwith ("CONTRACT_NOT_FOUND") : contract (inventory_parameter))
                         end;
 
                     const action : inventory_parameter = Assign_item (record [
-                        data = fi.data;
+                        data = (Map.empty: map (string, string));
                         instance_number = params.2;
                         item_id = params.1;
                     ]);
@@ -110,31 +110,32 @@ function freeze (const id: nat; var storage: storage): return is
         const found_item: option (item_metadata) = storage.warehouse [id];
 
         case found_item of 
-            None -> failwith("ITEM_ID_DOESNT_EXIST")
+            None -> failwith ("ITEM_ID_DOESNT_EXIST")
         |   Some (i) -> {
                 const no_update_after : option (timestamp) = i.no_update_after;
 
                 case no_update_after of
                     None -> skip
-                |   Some(t) -> {
+                |   Some (t) -> {
                     if Tezos.now >= t then {
-                        failwith("ITEM_IS_FROZEN");
+                        failwith ("ITEM_IS_FROZEN");
                     } else {
                         skip;
                     }
                 }
                 end;
 
-                i.no_update_after := Some(Tezos.now);
-                storage.warehouse := Big_map.update(i.item_id, Some(i), storage.warehouse);
+                var updated_i := i;
+                updated_i.no_update_after := Some (Tezos.now);
+                storage.warehouse := Big_map.update (i.item_id, Some (updated_i), storage.warehouse);
         }
         end;
     } with ((nil: list (operation)), storage)
 
 function main (const action : parameter; const storage : storage): return is
     case action of
-        Add_item (i) -> add(i, storage)
-    |   Assign_item_proxy (ap) -> assign(ap, storage)
-    |   Update_item (i) -> update(i, storage)
-    |   Freeze_item (id) -> freeze(id, storage)
+        Add_item (i) -> add (i, storage)
+    |   Assign_item_proxy (ap) -> assign (ap, storage)
+    |   Update_item (i) -> update (i, storage)
+    |   Freeze_item (id) -> freeze (id, storage)
     end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jwalab/tokenization-service-contracts",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "files": [
         "index.js",
         "dist",

--- a/test/assign_item.test.js
+++ b/test/assign_item.test.js
@@ -45,13 +45,11 @@ contract("Given Warehouse and Inventory are deployed", () => {
                 warehouseStorage = await warehouseInstance.storage();
             });
 
-            it("Then assigns the item to the inventory", async () => {
+            it("Then assigns the item to the inventory AND the data field is empty", async () => {
                 const obj = await getInventoryItemtAt(inventoryStorage, 9, 1);
 
                 expect(obj).to.deep.eql({
-                    data: {
-                        XP: "97"
-                    }
+                    data: {}
                 });
             });
 


### PR DESCRIPTION
- Assigning an item sets an emtpy map in the inventory